### PR TITLE
Add missing field - pinholefocallength

### DIFF
--- a/src/OpenTrackIOSample.cpp
+++ b/src/OpenTrackIOSample.cpp
@@ -230,6 +230,7 @@ namespace opentrackio
         }
 
         assignJson(baseJson["lens"], "fStop", lens->fStop);
+        assignJson(baseJson["lens"], "pinholeFocalLength", lens->pinholeFocalLength);
         assignJson(baseJson["lens"], "focusDistance", lens->focusDistance);
 
         if (lens->projectionOffset.has_value())


### PR DESCRIPTION
Fixing bug where 'pinholeFocalLength' was not being set within `parseLensToJson()`, causing `generateJson()` to never include the 'pinholeFocalLength' field.