### PR TITLE
Fix: prevent implicit creation of "ptp" field when cleaning syncJson

### DIFF
--- a/src/OpenTrackIOProperties.cpp
+++ b/src/OpenTrackIOProperties.cpp
@@ -617,11 +617,14 @@ namespace opentrackio::opentrackioproperties
 
         OpenTrackIOHelpers::assignField(syncJson, "present", outSync.present, "bool", errors);
 
-        if (syncJson.contains("ptp") && outSync.source == Synchronization::SourceType::PTP)
+        if (syncJson.contains("ptp"))
         {
-            outSync.ptp = parsePtp(syncJson, errors);
+            if (outSync.source == Synchronization::SourceType::PTP)
+            {
+                outSync.ptp = parsePtp(syncJson, errors);
+            }
+            OpenTrackIOHelpers::clearFieldIfEmpty(syncJson, "ptp");
         }
-        OpenTrackIOHelpers::clearFieldIfEmpty(syncJson, "ptp");
 
         return outSync;
     }


### PR DESCRIPTION
Refactors the handling of the "ptp" field so that both parsing and cleanup occur only when the key is actually present in the JSON object.

clearFieldIfEmpty() internally uses operator[], which implicitly inserts "ptp": null when the field does not exist. This caused validation warnings such as:

  Key: timing was still remaining after parsing.
  Key: synchronization was still remaining after parsing.
  Key: ptp was still remaining after parsing.