### PR TITLE
Fix: correct timing/mode optional handling and invalid value detection

### DIFF
--- a/src/OpenTrackIOProperties.cpp
+++ b/src/OpenTrackIOProperties.cpp
@@ -484,7 +484,7 @@ namespace opentrackio::opentrackioproperties
             timing.mode = str == "external" ? Mode::EXTERNAL : Mode::INTERNAL;
             timingJson.erase("mode");
         }
-        else
+        else if (str.has_value())
         {
             errors.emplace_back("field: timing/mode has an invalid string value.");
             timing.mode = std::nullopt;

--- a/src/OpenTrackIOProperties.cpp
+++ b/src/OpenTrackIOProperties.cpp
@@ -479,7 +479,7 @@ namespace opentrackio::opentrackioproperties
 
         std::optional<std::string> str;
         OpenTrackIOHelpers::assignField(timingJson, "mode", str, "string", errors);
-        if (str.has_value() && (str == "external" || "internal"))
+        if (str.has_value() && (str == "external" || str == "internal"))
         {
             timing.mode = str == "external" ? Mode::EXTERNAL : Mode::INTERNAL;
             timingJson.erase("mode");


### PR DESCRIPTION
The JSON schema defines timing.mode as an optional string field.
The previous implementation treated the absence of this field as an invalid value, causing Timing::parse() to emit an error and making OpenTrackIOSample::initialise() return false even for valid inputs.

This change ensures that an error is only reported when timing.mode is present but contains an invalid string. Missing values are now accepted as valid, matching the schema and preventing false‑negative parsing failures.