### PR TITLE
Added support for multiplatform shared lib symbol export/import.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 
 target_sources(${PROJECT_NAME} PRIVATE ${source_list})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
+add_compile_definitions(OPENTRACKIO_BUILD)
 
 # Handle debug vs release builds and their separate libs
 

--- a/include/opentrackio-cpp/OpenTrackIOProperties.h
+++ b/include/opentrackio-cpp/OpenTrackIOProperties.h
@@ -23,6 +23,16 @@
 #define OPEN_TRACK_IO_PROTOCOL_MINOR_VERSION 0
 #define OPEN_TRACK_IO_PROTOCOL_PATCH         1
 
+#ifdef _MSC_VER
+    #ifdef OPENTRACKIO_BUILD
+        #define EXPORT __declspec(dllexport)
+    #else
+        #define EXPORT __declspec(dllimport)
+    #endif
+#else // Support for GCC and Clang.
+    #define EXPORT __attribute__((visibility("default")))
+#endif
+
 namespace opentrackio::opentrackioproperties
 {
     /** Duration of the clip.
@@ -305,8 +315,8 @@ namespace opentrackio::opentrackioproperties
     struct SourceNumber
     {
         /**
-	    * Number that identifies the index of the stream from a source from which data is being transported.
-	    * This is most important in the case where a source is producing multiple streams of samples. */
+        * Number that identifies the index of the stream from a source from which data is being transported.
+        * This is most important in the case where a source is producing multiple streams of samples. */
         uint32_t value;
 
         static std::optional<SourceNumber> parse(nlohmann::json& json, std::vector<std::string>& errors);

--- a/include/opentrackio-cpp/OpenTrackIOSample.h
+++ b/include/opentrackio-cpp/OpenTrackIOSample.h
@@ -19,7 +19,7 @@
 
 namespace opentrackio
 {
-    struct OpenTrackIOSample
+    struct EXPORT OpenTrackIOSample
     {
         std::optional<opentrackioproperties::Camera> camera = std::nullopt;
         std::optional<opentrackioproperties::Duration> duration = std::nullopt;


### PR DESCRIPTION
Currently when shared libraries are built on Windows, symbols are not exported by the compiler by default resulting in empty DLL files with no additional linkage artefacts, preventing its use in established codebases. 

This change implements a set of macros to correctly mark classes with the required decorators ensuring all intended objects are exported from the built library correctly.
